### PR TITLE
fix line continuation bug

### DIFF
--- a/scripts/load_updated_coherence_matrix.py
+++ b/scripts/load_updated_coherence_matrix.py
@@ -20,10 +20,10 @@ def main():
 
     # Copy file from S3 into filesystem
     s3 = boto3.client('s3')
-    s3.download_file(Bucket=config.get('AWS', 'bucketName'),
-                     Key=f'{args.site}/{args.beam}/CoherenceMatrix.csv',
-                     Filename=f'Data/{args.site} \
-                               /{args.beam}/CoherenceMatrix.csv')
+    s3.download_file(
+        Bucket=config.get('AWS', 'bucketName'),
+        Key=f'{args.site}/{args.beam}/CoherenceMatrix.csv',
+        Filename=f'Data/{args.site}/{args.beam}/CoherenceMatrix.csv')
 
 
 def get_config_params(args):
@@ -37,7 +37,7 @@ def get_config_params(args):
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Copy latest coherence matrix into ")
+        description="Copy latest coherence matrix into dashboard application")
     parser.add_argument("--site",
                         type=str,
                         help="Volcano Site Name, i.e. 'Meager'",


### PR DESCRIPTION
There was a bug where coherence matrices weren't updating properly. Analysts needed to update them manually to see new data. 

An error was discovered in:
https://github.com/Volcano-Risk-Reduction-in-Canada/Volcanic-Interpretation-Workbench/blob/main/scripts/load_updated_coherence_matrix.py

This was probably the result of an attempt to pass linting quality check fine line length but the line continuation was not implemented properly