### PR TITLE
Add --host and --port CLI arguments

### DIFF
--- a/app/dash_app.py
+++ b/app/dash_app.py
@@ -10,6 +10,7 @@ Authors:
   - Drew Rotheram <drew.rotheram-clarke@nrcan-rncan.gc.ca>
   - Nick Ackerley <nicholas.ackerley@nrcan-rncan.gc.ca>
 """
+import argparse
 
 import dash
 
@@ -17,6 +18,21 @@ from dash import html, Dash
 import dash_bootstrap_components as dbc
 # from dash_extensions.enrich import (DashProxy,
 #                                     MultiplexerTransform)
+
+parser = argparse.ArgumentParser(
+    description='Serve Volcanic Interpretation Workbench'
+)
+parser.add_argument(
+    '--host', type=str,
+    help='Address on which to run the server',
+    default='0.0.0.0'
+)
+parser.add_argument(
+    '--port', type=str,
+    help="Port on which to run the server",
+    default="8050"
+)
+args = parser.parse_args()
 
 app = Dash(__name__,
            prevent_initial_callbacks=True,
@@ -33,4 +49,4 @@ app.layout = html.Div([
 ])
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(debug=True, host=args.host, port=args.port)


### PR DESCRIPTION
Use `argparse` to add optional `--host` and `--port` CLI arguments. These arguments are passed to `app.run()` on dash app startup. Configurable host and port will be useful for deployment of the dashboard.