### PR TITLE
Create docker-build.yml

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,21 @@
+name: Docker Build
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker Image
+      run: docker build -t volc_interp_wb .
+    - name: Build Docker Container
+      run: |
+        docker run -p 8050:8050/tcp --name volc_interp_wb volc_interp_wb &
+        # FUTURE (when config PR is merged to main)
+        # docker-compose up

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Docker Build
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "bug/use-environment-variable" ]
 
 jobs:
   build:


### PR DESCRIPTION
Create a Github Action Workflow to build a docker container.

**Update on blocker**
I made 2 changes that get around the blocker.

1. change the merge branch from `main` to `bug/use-environment-variable`. This means that we should first merge this branch `feature/gh-action-build-container-dockerfile-1` into `bug/use-environment-variable` before merging everything into `main`.
2.  change one line in `./github/workflows/docker-build-test.yml` to allow for the github action to be run on a pull request to `bug/use-environment-variable` _as well as_ `main` branch. Once everything gets merged to `bug/use-environment-variable`, we can remove this change.

**Blocker**
When running the workflow, we come across the error of `config.ini` not being found. As we are moving away from using `config.ini`, we will need to test this workflow again when changes from [this PR](https://github.com/Volcano-Risk-Reduction-in-Canada/Volcanic-Interpretation-Workbench/pull/50) are approved and merged into main.
![image](https://github.com/Volcano-Risk-Reduction-in-Canada/Volcanic-Interpretation-Workbench/assets/66324599/5c2f603f-d2e6-446d-9e4a-bf0eefabd20f)
